### PR TITLE
Resolve ember-modifier 3.2 deprecations

### DIFF
--- a/addon/modifiers/auto-focus.js
+++ b/addon/modifiers/auto-focus.js
@@ -3,16 +3,22 @@ import focus from '../utils/focus';
 import { scheduleOnce } from '@ember/runloop';
 
 export default class AutoFocusModifier extends Modifier {
-  didInstall() {
-    const { disabled } = this.args.named;
+  didSetup = false;
+
+  modify(element, positional, named) {
+    if (this.didSetup) {
+      return;
+    }
+
+    this.didSetup = true;
+
+    const { disabled } = named;
 
     if (disabled) {
       return;
     }
 
-    let { element } = this;
-
-    const selector = this.args.positional[0];
+    const selector = positional[0];
 
     if (selector) {
       element = element.querySelector(selector);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.1.0"
+        "ember-modifier": "^3.2.0"
       },
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
@@ -10530,14 +10530,14 @@
       }
     },
     "node_modules/ember-modifier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.1.0.tgz",
-      "integrity": "sha512-G5Lj9jVFsD2sVJcRNQfaGKG1p81wT4LGfClBhCuB4TgwP1NGJKdqI+Q8BW2MptONxQt/71UjjUH0YK7Gm9eahg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^4.2.1",
+        "ember-cli-typescript": "^5.0.0",
         "ember-compatibility-helpers": "^1.2.5"
       },
       "engines": {
@@ -10545,9 +10545,9 @@
       }
     },
     "node_modules/ember-modifier/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.0.0.tgz",
+      "integrity": "sha512-UDKZlG7bInRo7eDsF3jvPz1Dxh1YvRhMw9wyj5rj2K3brw0xEh1IMTqPgWRbPESqjcWuwa8s0FCNuYWDc4PTfg==",
       "dependencies": {
         "ansi-to-html": "^0.6.15",
         "broccoli-stew": "^3.0.0",
@@ -10561,7 +10561,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-modifier/node_modules/execa": {
@@ -33248,21 +33248,21 @@
       }
     },
     "ember-modifier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.1.0.tgz",
-      "integrity": "sha512-G5Lj9jVFsD2sVJcRNQfaGKG1p81wT4LGfClBhCuB4TgwP1NGJKdqI+Q8BW2MptONxQt/71UjjUH0YK7Gm9eahg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
       "requires": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^4.2.1",
+        "ember-cli-typescript": "^5.0.0",
         "ember-compatibility-helpers": "^1.2.5"
       },
       "dependencies": {
         "ember-cli-typescript": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-          "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.0.0.tgz",
+          "integrity": "sha512-UDKZlG7bInRo7eDsF3jvPz1Dxh1YvRhMw9wyj5rj2K3brw0xEh1IMTqPgWRbPESqjcWuwa8s0FCNuYWDc4PTfg==",
           "requires": {
             "ansi-to-html": "^0.6.15",
             "broccoli-stew": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.0.1",
-    "ember-modifier": "^3.1.0"
+    "ember-modifier": "^3.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
This resolves all ember-modifier v3.2 deprecations by switching to the `modify` hook based implementation.

More information: https://github.com/ember-modifier/ember-modifier/blob/v3/MIGRATIONS.md#migrations